### PR TITLE
Refactor: Move install scripts to scripts/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ See NameTidy in action:
 
 ## Table of Contents
 
-- [Download](#download)
+- [Automated Installation](#automated-installation)
+  - [For Linux/macOS (using `install.sh`)](#for-linuxmacos-using-installsh)
+  - [For Windows Command Prompt (using `install.cmd`)](#for-windows-command-prompt-using-installcmd)
+  - [For Windows PowerShell (using `install.ps1`)](#for-windows-powershell-using-installps1)
+- [Manual Installation](#manual-installation)
 - [Build](#build)
 - [Usage](#usage)
   - [Clean Up Filenames](#clean-up-filenames)
@@ -30,25 +34,96 @@ See NameTidy in action:
 
 ---
 
-## Download
+## Automated Installation
+
+You can use the following scripts to automate the installation of NameTidy. These scripts will detect your system's architecture and download the appropriate binary.
+
+### For Linux/macOS (using `install.sh`)
+
+1.  **Download the script (it will be saved as `install.sh` in your current directory):**
+    ```bash
+    # Using curl:
+    curl -LO https://raw.githubusercontent.com/mi8bi/NameTidy/main/scripts/install.sh
+    # Or using wget:
+    # wget https://raw.githubusercontent.com/mi8bi/NameTidy/main/scripts/install.sh
+    ```
+
+2.  **Make it executable:**
+    ```bash
+    chmod +x install.sh
+    ```
+
+3.  **Run the installer:**
+    ```bash
+    ./install.sh
+    ```
+    This script installs `nametidy` to `/usr/local/bin`. It may require `sudo` privileges if your user doesn't have write access to this directory.
+
+### For Windows Command Prompt (using `install.cmd`)
+
+1.  **Download the script:**
+    You can download `install.cmd` directly from the repository (e.g., save it to your `Downloads` folder):
+    [https://raw.githubusercontent.com/mi8bi/NameTidy/main/scripts/install.cmd](https://raw.githubusercontent.com/mi8bi/NameTidy/main/scripts/install.cmd)
+    (Right-click the link and select "Save link as..." or "Save As...")
+
+2.  **Run the installer:**
+    Open Command Prompt (`cmd.exe`). Navigate to the directory where you saved `install.cmd` (e.g., `Downloads`) and run it:
+    ```cmd
+    cd C:\Users\YourUser\Downloads
+    install.cmd
+    ```
+    Or, if `install.cmd` is in your current directory:
+    ```cmd
+    install.cmd
+    ```
+    This script installs `nametidy.exe` to `%USERPROFILE%\bin` and attempts to add this directory to your User PATH environment variable. PATH changes will apply to new Command Prompt sessions.
+
+### For Windows PowerShell (using `install.ps1`)
+
+1.  **Download the script:**
+    You can download `install.ps1` directly from the repository (e.g., save it to your `Downloads` folder):
+    [https://raw.githubusercontent.com/mi8bi/NameTidy/main/scripts/install.ps1](https://raw.githubusercontent.com/mi8bi/NameTidy/main/scripts/install.ps1)
+    (Right-click the link and select "Save link as..." or "Save As...")
+
+2.  **Run the installer:**
+    Open PowerShell. Navigate to the directory where you saved `install.ps1` (e.g., `Downloads`). You may need to adjust your execution policy to run the script.
+    Example:
+    ```powershell
+    cd C:\Users\YourUser\Downloads
+    # Then run one of the following:
+    ```
+    To run the script for the current session without changing global policy:
+    ```powershell
+    PowerShell -ExecutionPolicy Bypass -File .\install.ps1
+    ```
+    Alternatively, from within that PowerShell prompt:
+    ```powershell
+    # Temporarily bypass execution policy for the current process
+    Set-ExecutionPolicy Bypass -Scope Process -Force
+    .\install.ps1
+    ```
+    This script installs `nametidy.exe` to `$env:USERPROFILE\bin` and attempts to add this directory to your User PATH environment variable persistently. PATH changes will apply to new PowerShell sessions or after restarting Windows.
+
+---
+
+## Manual Installation
 
 You can download prebuilt binaries from the [GitHub Releases page](https://github.com/mi8bi/NameTidy/releases):
 
 1. Go to the [Releases](https://github.com/mi8bi/NameTidy/releases) page on GitHub.
-2. Find the latest release and download the binary file for your OS and architecture.
-3. Extract the archive if needed, for example:
-
-```bash
-tar -xzvf NameTidy_0.1.0_linux_amd64.tar.gz
-```
-
-4. Move the executable to a directory in your PATH, for example:
-
-```bash
-mv NameTidy /usr/local/bin/
-```
-
-5. Run NameTidy --help to verify installation.
+2. Find the latest release and download the binary file for your OS and architecture (e.g., `NameTidy_windows_amd64.zip` or `NameTidy_linux_amd64.tar.gz`).
+3. Extract the archive. For `.tar.gz` files on Linux/macOS:
+   ```bash
+   tar -xzvf NameTidy_VERSION_OS_ARCH.tar.gz
+   ```
+   For `.zip` files on Windows, you can use File Explorer's built-in "Extract All..." option.
+4. Move the extracted `nametidy` (or `nametidy.exe` on Windows) executable to a directory in your system's PATH.
+   - For Linux/macOS, a common location is `/usr/local/bin/`:
+     ```bash
+     sudo mv nametidy /usr/local/bin/
+     ```
+   - For Windows, you might choose a directory like `%USERPROFILE%\bin\` and ensure this directory is added to your PATH environment variable.
+5. Run `nametidy --help` (or `nametidy.exe --help` on Windows) to verify the installation.
 
 ## Build
 

--- a/scripts/.gitkeep
+++ b/scripts/.gitkeep
@@ -1,0 +1,2 @@
+# This placeholder file is used to ensure the 'scripts' directory is tracked by Git.
+# You can remove this file if you add other files to this directory.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,160 @@
+#Requires -Version 5.0
+<#
+.SYNOPSIS
+    Installs the NameTidy utility for Windows.
+.DESCRIPTION
+    This script downloads the latest version of NameTidy for the appropriate
+    architecture, extracts it, installs it to $env:USERPROFILE\bin, and
+    attempts to add this directory to the user's PATH environment variable.
+.NOTES
+    Author: AI Assistant
+    Version: 1.0
+#>
+
+# Stop on first error
+$ErrorActionPreference = 'Stop'
+
+# --- Configuration ---
+$BinaryName = "nametidy.exe"
+$InstallBaseDir = $env:USERPROFILE
+$InstallRelativePath = "bin" # Relative to InstallBaseDir
+$InstallDir = Join-Path -Path $InstallBaseDir -ChildPath $InstallRelativePath
+
+$ReleaseBaseUrl = "https://github.com/mi8bi/NameTidy/releases/latest/download"
+$OsName = "windows"
+$Architecture = ""
+
+# --- Temporary Path ---
+# Create a temporary directory for downloads and extraction
+$TempDir = Join-Path -Path $env:TEMP -ChildPath "NameTidy_Install_$($PID)_$(Get-Random)"
+try {
+    if (Test-Path $TempDir) {
+        Write-Warning "Temporary directory $TempDir already exists. Removing."
+        Remove-Item -Path $TempDir -Recurse -Force
+    }
+    New-Item -Path $TempDir -ItemType Directory -Force | Out-Null
+    Write-Host "Temporary directory created: $TempDir"
+}
+catch {
+    Write-Error "Failed to create temporary directory '$TempDir'. Error: $($_.Exception.Message)"
+    exit 1
+}
+
+# --- Main Script Logic ---
+try {
+    Write-Host "NameTidy Installer for Windows PowerShell"
+    Write-Host "---------------------------------------"
+
+    # --- Determine Architecture ---
+    Write-Host "Detecting system architecture..."
+    switch ($env:PROCESSOR_ARCHITECTURE) {
+        "AMD64" { $Architecture = "amd64" }
+        "ARM64" { $Architecture = "arm64" }
+        default {
+            throw "Unsupported architecture: $($env:PROCESSOR_ARCHITECTURE). Only AMD64 and ARM64 are supported."
+        }
+    }
+    Write-Host "Detected Architecture: $Architecture"
+
+    # --- Construct Download URL ---
+    $AssetName = "NameTidy_${OsName}_${Architecture}.zip"
+    $DownloadUrl = "$ReleaseBaseUrl/$AssetName"
+    $ArchiveFilePath = Join-Path -Path $TempDir -ChildPath $AssetName
+    $ExtractedBinaryPath = Join-Path -Path $TempDir -ChildPath $BinaryName # Assuming it's at the root of the zip
+
+    Write-Host "Download URL: $DownloadUrl"
+
+    # --- Download ---
+    Write-Host "Downloading NameTidy release asset..."
+    try {
+        Invoke-WebRequest -Uri $DownloadUrl -OutFile $ArchiveFilePath -UseBasicParsing
+        Write-Host "Download successful: $ArchiveFilePath"
+    }
+    catch {
+        throw "Download failed from $DownloadUrl. Error: $($_.Exception.Message). Please check the URL, your internet connection, or if an asset for '$OsName/$Architecture' is available."
+    }
+
+    # --- Extraction ---
+    Write-Host "Extracting $BinaryName from $ArchiveFilePath..."
+    try {
+        # Expand-Archive extracts all files. We assume nametidy.exe is at the root of the zip.
+        Expand-Archive -Path $ArchiveFilePath -DestinationPath $TempDir -Force
+        if (-not (Test-Path $ExtractedBinaryPath)) {
+            throw "$BinaryName not found in the extracted files at $TempDir. The archive might not contain '$BinaryName' at its root."
+        }
+        Write-Host "Extraction successful. $BinaryName is at $ExtractedBinaryPath"
+    }
+    catch {
+        throw "Extraction failed. Error: $($_.Exception.Message). The archive might be corrupt or incompatible."
+    }
+
+    # --- Installation ---
+    Write-Host "Installing $BinaryName..."
+
+    # Create installation directory if it doesn't exist
+    if (-not (Test-Path $InstallDir)) {
+        Write-Host "Creating installation directory: $InstallDir"
+        New-Item -Path $InstallDir -ItemType Directory -Force | Out-Null
+    }
+
+    $FinalInstallPath = Join-Path -Path $InstallDir -ChildPath $BinaryName
+
+    # Check if binary already exists and prompt for overwrite
+    if (Test-Path $FinalInstallPath) {
+        Write-Warning "$BinaryName already exists at $FinalInstallPath."
+        $overwriteChoice = Read-Host "Do you want to overwrite it? (Y/N)"
+        if ($overwriteChoice -ne 'Y' -and $overwriteChoice -ne 'y') {
+            Write-Host "Overwrite cancelled by user. Exiting."
+            # No error, graceful exit. Cleanup will still run.
+            return
+        }
+        Write-Host "Proceeding with overwrite..."
+    }
+
+    # Move the binary
+    try {
+        Move-Item -Path $ExtractedBinaryPath -Destination $FinalInstallPath -Force
+        Write-Host "$BinaryName successfully installed to $FinalInstallPath."
+    }
+    catch {
+        throw "Failed to move $BinaryName to $FinalInstallPath. Error: $($_.Exception.Message). Check permissions."
+    }
+
+    # --- PATH Update ---
+    Write-Host "Attempting to add $InstallDir to your User PATH..."
+    try {
+        $currentUserPath = [System.Environment]::GetEnvironmentVariable('Path', 'User')
+        $pathParts = $currentUserPath -split ';' | Where-Object { $_ -ne '' } # Remove empty entries
+
+        if ($pathParts -notcontains $InstallDir) {
+            $newPath = ($pathParts + $InstallDir) -join ';'
+            [System.Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+            Write-Host "$InstallDir added to User PATH. Changes will apply to new PowerShell sessions/Windows logon."
+            Write-Host "You might need to restart your current PowerShell session or log out and back in."
+        } else {
+            Write-Host "$InstallDir is already in the User PATH."
+        }
+    }
+    catch {
+        Write-Warning "Failed to automatically add $InstallDir to User PATH. Error: $($_.Exception.Message)"
+        Write-Warning "You may need to add it manually through System Properties (Environment Variables)."
+    }
+
+    Write-Host "Installation complete!"
+    Write-Host "Please open a new PowerShell session or terminal to use $BinaryName."
+
+}
+catch {
+    # Catch any error that occurred in the main try block
+    Write-Error "An error occurred during installation: $($_.Exception.Message)"
+    Write-Error "Script execution aborted."
+    # Exit with an error code if desired, e.g., exit 1, though script will terminate anyway.
+}
+finally {
+    # --- Cleanup ---
+    if (Test-Path $TempDir) {
+        Write-Host "Cleaning up temporary directory: $TempDir"
+        Remove-Item -Path $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    Write-Host "Installer finished."
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+
+# Script to download and install the latest NameTidy binary
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# --- Global Variables ---
+TMP_DIR="" # Initialize TMP_DIR, will be set in main
+BINARY_NAME="nametidy"
+INSTALL_PATH="/usr/local/bin"
+INSTALLED_BINARY_PATH="${INSTALL_PATH}/${BINARY_NAME}"
+EXTRACTED_BINARY_PATH="" # Will be set after extraction
+
+# --- Helper Functions ---
+# Function to clean up temporary directory on exit
+cleanup() {
+    if [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
+        # Check if the binary still exists in TMP_DIR (i.e., wasn't moved)
+        # This check is mainly for interactive scenarios; if script exits due to error, it's cleaned.
+        if [ -f "$EXTRACTED_BINARY_PATH" ]; then
+            echo "Note: The extracted binary '$EXTRACTED_BINARY_PATH' was not moved to $INSTALL_PATH."
+            echo "Cleaning up temporary directory, including the binary."
+        else
+            echo "Cleaning up temporary directory: $TMP_DIR"
+        fi
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# Trap EXIT, ERR, and INT signals to call cleanup function
+# ERR is for set -e
+# INT is for Ctrl+C
+trap cleanup EXIT ERR INT
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to download using curl or wget
+download_file() {
+    local url="$1"
+    local output_path="$2"
+
+    if command_exists curl; then
+        echo "Attempting to download with curl..."
+        # -L: follow redirects, -S: show errors, -s: silent, -f: fail fast (HTTP errors => exit code 22)
+        if curl -LSsf -o "$output_path" "$url"; then
+            echo "Download successful: $output_path"
+            return 0
+        else
+            echo "curl download failed. HTTP error or other issue."
+            return 1 # curl with -f already returns non-zero on server errors
+        fi
+    elif command_exists wget; then
+        echo "Attempting to download with wget..."
+        # -q: quiet, -O: output file
+        if wget -q -O "$output_path" "$url"; then
+            echo "Download successful: $output_path"
+            return 0
+        else
+            echo "wget download failed."
+            return 1
+        fi
+    else
+        echo "Error: Neither curl nor wget found. Please install one of them and try again."
+        exit 1 # This will trigger ERR trap and then EXIT trap
+    fi
+}
+
+# --- Main Script ---
+echo "NameTidy Installer"
+echo "------------------"
+
+# Create a temporary directory for download
+# mktemp -d will create a directory with a unique name
+TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'nametidy-install.XXXXXXXXXX')
+if [ ! -d "$TMP_DIR" ]; then
+    echo "Error: Failed to create temporary directory."
+    exit 1
+fi
+# Set EXTRACTED_BINARY_PATH now that TMP_DIR is known
+EXTRACTED_BINARY_PATH="${TMP_DIR}/${BINARY_NAME}"
+echo "Temporary directory created: $TMP_DIR"
+
+
+# Determine OS and Architecture
+OS=""
+ARCH=""
+
+echo "Detecting OS and architecture..."
+case "$(uname -s)" in
+    Linux*)     OS="linux";;
+    Darwin*)    OS="darwin";;
+    *)          echo "Error: Unsupported OS: $(uname -s)"; exit 1;;
+esac
+
+case "$(uname -m)" in
+    x86_64)     ARCH="amd64";;
+    arm64)      ARCH="arm64";;
+    aarch64)    ARCH="arm64";;
+    *)          echo "Error: Unsupported architecture: $(uname -m)"; exit 1;;
+esac
+
+echo "Detected OS: $OS"
+echo "Detected Architecture: $ARCH"
+
+# Construct the download URL
+RELEASE_BASE_URL="https://github.com/mi8bi/NameTidy/releases/latest/download"
+ASSET_NAME="NameTidy_${OS}_${ARCH}.tar.gz"
+DOWNLOAD_URL="${RELEASE_BASE_URL}/${ASSET_NAME}"
+
+echo "Constructed download URL: $DOWNLOAD_URL"
+
+# Define download path
+ARCHIVE_PATH="${TMP_DIR}/${ASSET_NAME}"
+
+# Download the archive
+echo "Downloading NameTidy release asset..."
+if ! download_file "$DOWNLOAD_URL" "$ARCHIVE_PATH"; then
+    echo "Error: Download failed from $DOWNLOAD_URL."
+    echo "Please check the URL and your internet connection."
+    echo "It's possible that a release asset for your OS/architecture ($OS/$ARCH) is not available."
+    exit 1
+fi
+
+# Extract the binary
+echo "Extracting the binary..."
+if ! command_exists tar; then
+    echo "Error: 'tar' command not found. Please install tar and try again."
+    exit 1
+fi
+
+# Extracting only the 'nametidy' binary from the archive to the temp directory's root
+if ! tar -xzf "$ARCHIVE_PATH" -C "$TMP_DIR" "$BINARY_NAME"; then
+    echo "Error: Failed to extract '$BINARY_NAME' from '$ARCHIVE_PATH'."
+    echo "The archive might be corrupted, the binary name/path inside the archive is unexpected,"
+    echo "or the binary for your system ($OS/$ARCH) might not be correctly packaged as '$BINARY_NAME'."
+    exit 1
+fi
+echo "Binary '$BINARY_NAME' extracted to '$EXTRACTED_BINARY_PATH'"
+
+# Clean up downloaded archive
+rm "$ARCHIVE_PATH"
+
+# Check if binary exists and prompt for overwrite
+if [ -f "$INSTALLED_BINARY_PATH" ]; then
+    echo "Warning: '$BINARY_NAME' already exists at $INSTALLED_BINARY_PATH."
+    # Disable set -e for this interactive block
+    set +e
+    read -r -p "Do you want to overwrite it? (y/N): " overwrite_choice
+    set -e
+    case "$overwrite_choice" in
+        y|Y ) echo "Proceeding with overwrite...";;
+        * )   echo "Overwrite cancelled by user. Exiting."; exit 0;; # Graceful exit, trap will clean TMP_DIR
+    esac
+fi
+
+# Make the binary executable
+echo "Making '$BINARY_NAME' executable..."
+if ! chmod +x "$EXTRACTED_BINARY_PATH"; then
+    echo "Error: Failed to make binary executable. Please check permissions for '$EXTRACTED_BINARY_PATH'."
+    exit 1
+fi
+
+# Move the binary to the installation path
+echo "Attempting to install '$BINARY_NAME' to $INSTALL_PATH..."
+
+# Create install directory if it doesn't exist (relevant for /usr/local/bin but good practice)
+# This usually requires sudo as well.
+if [ ! -d "$INSTALL_PATH" ]; then
+    echo "Installation directory $INSTALL_PATH does not exist. Attempting to create it..."
+    if command_exists sudo; then
+        if ! sudo mkdir -p "$INSTALL_PATH"; then
+            echo "Error: Failed to create $INSTALL_PATH even with sudo."
+            echo "Please create $INSTALL_PATH manually and try again."
+            exit 1
+        fi
+        echo "$INSTALL_PATH created."
+    else
+        echo "Error: $INSTALL_PATH does not exist and sudo is not available to create it."
+        echo "Please create $INSTALL_PATH manually and try again."
+        exit 1
+    fi
+fi
+
+
+# Try direct move first
+if mv "$EXTRACTED_BINARY_PATH" "$INSTALLED_BINARY_PATH" 2>/dev/null; then
+    echo "Successfully installed '$BINARY_NAME' to $INSTALLED_BINARY_PATH."
+else
+    echo "Direct move failed (likely due to permissions)."
+    if command_exists sudo; then
+        echo "Attempting to move with sudo..."
+        if sudo mv "$EXTRACTED_BINARY_PATH" "$INSTALLED_BINARY_PATH"; then
+            echo "Successfully installed '$BINARY_NAME' to $INSTALLED_BINARY_PATH with sudo."
+        else
+            echo "Error: 'sudo mv' failed. You might not have sudo privileges or entered the wrong password."
+            echo "The extracted binary is available at: $EXTRACTED_BINARY_PATH"
+            echo "Please move it manually to a directory in your PATH."
+            echo "Example: sudo mv '$EXTRACTED_BINARY_PATH' '$INSTALLED_BINARY_PATH'"
+            set +e # Disable exit on error to allow prompt
+            read -r -p "Press Enter to finish the script (this will remove the temporary file), or Ctrl+C to abort and move it manually now."
+            set -e
+            exit 1 # Indicate an issue occurred, trap will clean up.
+        fi
+    else
+        echo "Error: 'sudo' command not found."
+        echo "The extracted binary is available at: $EXTRACTED_BINARY_PATH"
+        echo "Please move it manually to a directory in your PATH."
+        echo "Example: mv '$EXTRACTED_BINARY_PATH' '$INSTALLED_BINARY_PATH' (you might need to be root or use sudo if available another way)"
+        set +e
+        read -r -p "Press Enter to finish the script (this will remove the temporary file), or Ctrl+C to abort and move it manually now."
+        set -e
+        exit 1 # Indicate an issue occurred, trap will clean up.
+    fi
+fi
+
+# Check if installation path is in PATH
+if [[ ":$PATH:" != *":${INSTALL_PATH}:"* ]]; then
+    echo ""
+    echo "Warning: Installation directory '$INSTALL_PATH' is not in your PATH."
+    echo "You may need to add it to your shell configuration file (e.g., ~/.bashrc, ~/.zshrc, or /etc/profile):"
+    echo "  export PATH=\"\$PATH:$INSTALL_PATH\""
+    echo "Then, source the file (e.g., 'source ~/.bashrc') or open a new terminal."
+fi
+
+echo ""
+echo "Installation of '$BINARY_NAME' complete!"
+echo "You can now try running '$BINARY_NAME' from your terminal."
+
+# Cleanup is handled by the trap on EXIT, ERR, INT.
+# Setting EXTRACTED_BINARY_PATH to empty if it was successfully moved, so cleanup doesn't show confusing message.
+EXTRACTED_BINARY_PATH=""
+exit 0


### PR DESCRIPTION
- Moved `install.sh`, `install.cmd`, and `install.ps1` into a new `scripts/` directory to keep the project root cleaner.
- Updated `README.md` to reflect the new paths for downloading and executing these scripts.
- Clarified download and execution instructions in the README for better user experience.