### PR TITLE
Fix(install): Update scripts to use versioned release asset URLs

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -45,6 +45,41 @@ try {
     Write-Host "NameTidy Installer for Windows PowerShell"
     Write-Host "---------------------------------------"
 
+    # --- Fetch Latest Release Information ---
+    Write-Host "Fetching latest release information..."
+    $LatestReleaseInfoUrl = "https://api.github.com/repos/mi8bi/NameTidy/releases/latest"
+    $TagName = ""
+    $Version = ""
+
+    try {
+        # Using -UseBasicParsing for compatibility, though for modern PowerShell it's often not needed.
+        $ReleaseInfo = Invoke-RestMethod -Uri $LatestReleaseInfoUrl -UseBasicParsing
+        $TagName = $ReleaseInfo.tag_name
+        if (-not $TagName) {
+            throw "tag_name not found in the release information from $LatestReleaseInfoUrl."
+        }
+        Write-Host "Latest release tag: $TagName"
+
+        # Remove 'v' prefix if it exists
+        if ($TagName.StartsWith("v")) {
+            $Version = $TagName.Substring(1)
+        } else {
+            # If no 'v' prefix, use the tag name as version directly.
+            # This might be relevant if tag naming changes, though GitHub convention is often vX.Y.Z
+            $Version = $TagName
+        }
+
+        if (-not $Version) {
+            throw "Could not extract version from tag '$TagName'."
+        }
+        Write-Host "Detected version: $Version"
+    }
+    catch {
+        # Specific error for this block, then re-throw to be caught by the main script's try-catch
+        Write-Error "Error fetching or parsing release information: $($_.Exception.Message)"
+        throw $_
+    }
+
     # --- Determine Architecture ---
     Write-Host "Detecting system architecture..."
     switch ($env:PROCESSOR_ARCHITECTURE) {
@@ -57,8 +92,13 @@ try {
     Write-Host "Detected Architecture: $Architecture"
 
     # --- Construct Download URL ---
-    $AssetName = "NameTidy_${OsName}_${Architecture}.zip"
-    $DownloadUrl = "$ReleaseBaseUrl/$AssetName"
+    # $OsName is already defined in Configuration section
+    # $Architecture is determined above
+    # $Version and $TagName are from the new block above
+    $AssetName = "NameTidy_${Version}_${OsName}_${Architecture}.zip"
+    # Construct specific download URL using the tag
+    $DownloadUrl = "https://github.com/mi8bi/NameTidy/releases/download/${TagName}/${AssetName}"
+    # Example: https://github.com/mi8bi/NameTidy/releases/download/v0.1.0/NameTidy_0.1.0_windows_amd64.zip
     $ArchiveFilePath = Join-Path -Path $TempDir -ChildPath $AssetName
     $ExtractedBinaryPath = Join-Path -Path $TempDir -ChildPath $BinaryName # Assuming it's at the root of the zip
 


### PR DESCRIPTION
The installation scripts (`install.sh`, `install.cmd`, `install.ps1`) were previously failing with 404 errors because they attempted to download release assets using a generic name (e.g., `NameTidy_linux_amd64.tar.gz`) from the `/latest/download/` URL.

The actual release assets are versioned (e.g., `NameTidy_0.1.0_linux_amd64.tar.gz`) and while `/latest/` correctly points to the latest release, the filename itself needs the version.

This commit updates all three scripts to:
1. Dynamically fetch the latest release tag (e.g., "v0.1.0") from the GitHub API (`https://api.github.com/repos/mi8bi/NameTidy/releases/latest`).
2. Extract the version number from the tag (e.g., "0.1.0").
3. Construct the asset filename using this version number (e.g., `NameTidy_0.1.0_{os}_{arch}.ext`).
4. Construct the download URL using the specific release tag (e.g., `https://github.com/mi8bi/NameTidy/releases/download/v0.1.0/NameTidy_0.1.0_{os}_{arch}.ext`).

This ensures the scripts download the correct, existing release assets, resolving the 404 errors. Error handling for the new fetching and parsing logic has been added to each script.