### PR TITLE
Fix(install): Improve binary extraction logic in install scripts

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -45,6 +45,41 @@ try {
     Write-Host "NameTidy Installer for Windows PowerShell"
     Write-Host "---------------------------------------"
 
+    # --- Fetch Latest Release Information ---
+    Write-Host "Fetching latest release information..."
+    $LatestReleaseInfoUrl = "https://api.github.com/repos/mi8bi/NameTidy/releases/latest"
+    $TagName = ""
+    $Version = ""
+
+    try {
+        # Using -UseBasicParsing for compatibility, though for modern PowerShell it's often not needed.
+        $ReleaseInfo = Invoke-RestMethod -Uri $LatestReleaseInfoUrl -UseBasicParsing
+        $TagName = $ReleaseInfo.tag_name
+        if (-not $TagName) {
+            throw "tag_name not found in the release information from $LatestReleaseInfoUrl."
+        }
+        Write-Host "Latest release tag: $TagName"
+
+        # Remove 'v' prefix if it exists
+        if ($TagName.StartsWith("v")) {
+            $Version = $TagName.Substring(1)
+        } else {
+            # If no 'v' prefix, use the tag name as version directly.
+            # This might be relevant if tag naming changes, though GitHub convention is often vX.Y.Z
+            $Version = $TagName
+        }
+
+        if (-not $Version) {
+            throw "Could not extract version from tag '$TagName'."
+        }
+        Write-Host "Detected version: $Version"
+    }
+    catch {
+        # Specific error for this block, then re-throw to be caught by the main script's try-catch
+        Write-Error "Error fetching or parsing release information: $($_.Exception.Message)"
+        throw $_
+    }
+
     # --- Determine Architecture ---
     Write-Host "Detecting system architecture..."
     switch ($env:PROCESSOR_ARCHITECTURE) {
@@ -57,8 +92,13 @@ try {
     Write-Host "Detected Architecture: $Architecture"
 
     # --- Construct Download URL ---
-    $AssetName = "NameTidy_${OsName}_${Architecture}.zip"
-    $DownloadUrl = "$ReleaseBaseUrl/$AssetName"
+    # $OsName is already defined in Configuration section
+    # $Architecture is determined above
+    # $Version and $TagName are from the new block above
+    $AssetName = "NameTidy_${Version}_${OsName}_${Architecture}.zip"
+    # Construct specific download URL using the tag
+    $DownloadUrl = "https://github.com/mi8bi/NameTidy/releases/download/${TagName}/${AssetName}"
+    # Example: https://github.com/mi8bi/NameTidy/releases/download/v0.1.0/NameTidy_0.1.0_windows_amd64.zip
     $ArchiveFilePath = Join-Path -Path $TempDir -ChildPath $AssetName
     $ExtractedBinaryPath = Join-Path -Path $TempDir -ChildPath $BinaryName # Assuming it's at the root of the zip
 
@@ -75,17 +115,50 @@ try {
     }
 
     # --- Extraction ---
-    Write-Host "Extracting $BinaryName from $ArchiveFilePath..."
+    Write-Host "Extracting archive from $ArchiveFilePath to $TempDir..."
     try {
-        # Expand-Archive extracts all files. We assume nametidy.exe is at the root of the zip.
         Expand-Archive -Path $ArchiveFilePath -DestinationPath $TempDir -Force
-        if (-not (Test-Path $ExtractedBinaryPath)) {
-            throw "$BinaryName not found in the extracted files at $TempDir. The archive might not contain '$BinaryName' at its root."
+        Write-Host "Archive extraction completed."
+
+        # Search for the binary, trying possible names
+        # $BinaryName is "nametidy.exe" (defined in Configuration)
+        $PossibleNames = @($BinaryName, "NameTidy.exe")
+        $FoundBinaryInfo = $null
+
+        foreach ($name_to_find in $PossibleNames) {
+            Write-Host "Searching for binary '$name_to_find' in '$TempDir'..."
+            # Get-ChildItem -File ensures we only get files, -Recurse searches subdirectories.
+            # Using -Filter for efficiency if supported, otherwise -Include. For simple names, -Filter is fine.
+            $foundFiles = Get-ChildItem -Path $TempDir -Recurse -File -Filter $name_to_find -ErrorAction SilentlyContinue
+
+            if ($foundFiles) {
+                # Take the first one if multiple are somehow found (e.g. in different subdirs or with same name)
+                $FoundBinaryInfo = $foundFiles | Select-Object -First 1
+                if ($FoundBinaryInfo) {
+                    # Update $ExtractedBinaryPath which was initially set to $TempDir\$BinaryName
+                    $ExtractedBinaryPath = $FoundBinaryInfo.FullName
+                    Write-Host "Found executable binary at: $ExtractedBinaryPath"
+                    break # Exit foreach loop as we found our binary
+                }
+            }
         }
-        Write-Host "Extraction successful. $BinaryName is at $ExtractedBinaryPath"
+
+        if (-not $FoundBinaryInfo) {
+            Write-Host "Listing contents of '$TempDir' (top level):"
+            Get-ChildItem -Path $TempDir -Depth 0 | ForEach-Object { Write-Host "  $($_.Name)" } # Depth 0 for top level
+            Write-Host "Listing contents of '$TempDir' (recursive, files only, relative paths):"
+            Get-ChildItem -Path $TempDir -Recurse -File | ForEach-Object { Write-Host "  $($_.FullName.Substring($TempDir.Length).TrimStart('\'))" }
+            throw "Could not find '$($PossibleNames -join "' or '")' in the extracted files at '$TempDir'."
+        }
+        # $ExtractedBinaryPath is now updated to the actual found binary path.
+        # The script will proceed to use this updated $ExtractedBinaryPath for installation.
+        # If "NameTidy.exe" was found, $ExtractedBinaryPath points to it.
+        # The $FinalInstallPath is $InstallDir\$BinaryName ("nametidy.exe").
+        # So, Move-Item will effectively rename "NameTidy.exe" to "nametidy.exe" if that was what was found. This is desired.
     }
     catch {
-        throw "Extraction failed. Error: $($_.Exception.Message). The archive might be corrupt or incompatible."
+        # This catch block handles errors from Expand-Archive or the 'throw' if binary not found.
+        throw "Extraction or binary search failed. Error: $($_.Exception.Message). The archive might be corrupt, incompatible, or the binary is missing/not found."
     }
 
     # --- Installation ---


### PR DESCRIPTION
The installation scripts were previously failing if the binary name inside the archive was not exactly "nametidy" (or "nametidy.exe") or if it was located in a subdirectory within the archive. This was primarily because the `tar` command was attempting to extract a specific file.

This commit updates all three installation scripts (`install.sh`, `install.cmd`, `install.ps1`) to:

1.  Extract the entire contents of the downloaded archive into a temporary directory.
    - For `install.sh` and `install.cmd` (when using `tar`), the `tar` command was modified to extract all files.
    - For `install.ps1` and `install.cmd` (when using PowerShell `Expand-Archive`), the existing behavior of full extraction is maintained.

2.  After extraction, search for the binary executable within the temporary directory. The search looks for likely variations:
    - `install.sh`: "nametidy" then "NameTidy".
    - `install.cmd` & `install.ps1`: "nametidy.exe" then "NameTidy.exe". The search is recursive.

3.  Use the path of the actual found binary for subsequent operations (permissions, moving to install directory).

4.  Ensure the binary is installed under the standard name ("nametidy" or "nametidy.exe") in the final installation path, regardless of how it was named or cased within the archive.

This makes the installation process more resilient to common variations in release archive packaging.