### PR TITLE
Refactor: Standardize naming to 'nametidy'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 > ✨ A fast and simple CLI tool to clean and rename file names — powered by Go.
 
-# [NameTidy](https://mi8bi.github.io/NameTidy/)
+# [nametidy](https://mi8bi.github.io/nametidy/)
 
-NameTidy is a fast and flexible command-line tool for cleaning and renaming file names.  
+nametidy is a fast and flexible command-line tool for cleaning and renaming file names.
 It supports operations such as filename cleanup, adding sequence numbers, and undoing changes — all with a simple and intuitive interface.
 
-[![Build Status](https://github.com/mi8bi/NameTidy/actions/workflows/test.yml/badge.svg)](https://github.com/mi8bi/NameTidy/actions/workflows/test.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/mi8bi/NameTidy)](https://goreportcard.com/report/github.com/mi8bi/NameTidy)
+[![Build Status](https://github.com/mi8bi/nametidy/actions/workflows/test.yml/badge.svg)](https://github.com/mi8bi/nametidy/actions/workflows/test.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/mi8bi/nametidy)](https://goreportcard.com/report/github.com/mi8bi/nametidy)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Latest Release](https://img.shields.io/github/v/release/mi8bi/NameTidy)](https://github.com/mi8bi/NameTidy/releases/latest)
-[![GitHub Stars](https://img.shields.io/github/stars/mi8bi/NameTidy?style=social)](https://github.com/mi8bi/NameTidy/stargazers)
+[![Latest Release](https://img.shields.io/github/v/release/mi8bi/nametidy)](https://github.com/mi8bi/nametidy/releases/latest)
+[![GitHub Stars](https://img.shields.io/github/stars/mi8bi/nametidy?style=social)](https://github.com/mi8bi/nametidy/stargazers)
 
 ---
 
 ## 📽️ Demo
 
-See NameTidy in action:
+See nametidy in action:
 
 [![NameTidy_Demo002](https://asciinema.org/a/719898.svg)](https://asciinema.org/a/719898)
 
@@ -42,16 +42,16 @@ See NameTidy in action:
 
 ## Automated Installation
 
-You can use the following scripts to automate the installation of NameTidy. These scripts will detect your system's architecture and download the appropriate binary.
+You can use the following scripts to automate the installation of nametidy. These scripts will detect your system's architecture and download the appropriate binary.
 
 ### For Linux/macOS (using `install.sh`)
 
 1.  **Download the script (it will be saved as `install.sh` in your current directory):**
     ```bash
     # Using curl:
-    curl -LO https://raw.githubusercontent.com/mi8bi/NameTidy/main/scripts/install.sh
+    curl -LO https://raw.githubusercontent.com/mi8bi/nametidy/main/scripts/install.sh
     # Or using wget:
-    # wget https://raw.githubusercontent.com/mi8bi/NameTidy/main/scripts/install.sh
+    # wget https://raw.githubusercontent.com/mi8bi/nametidy/main/scripts/install.sh
 
 2.  **Make it executable:**
     ```bash
@@ -68,7 +68,7 @@ You can use the following scripts to automate the installation of NameTidy. Thes
 
 1.  **Download the script:**
     You can download `install.cmd` directly from the repository (e.g., save it to your `Downloads` folder):
-    [https://raw.githubusercontent.com/mi8bi/NameTidy/main/scripts/install.cmd](https://raw.githubusercontent.com/mi8bi/NameTidy/main/scripts/install.cmd)
+    [https://raw.githubusercontent.com/mi8bi/nametidy/main/scripts/install.cmd](https://raw.githubusercontent.com/mi8bi/nametidy/main/scripts/install.cmd)
     (Right-click the link and select "Save link as..." or "Save As...")
 
 2.  **Run the installer:**
@@ -87,7 +87,7 @@ You can use the following scripts to automate the installation of NameTidy. Thes
 
 1.  **Download the script:**
     You can download `install.ps1` directly from the repository (e.g., save it to your `Downloads` folder):
-    [https://raw.githubusercontent.com/mi8bi/NameTidy/main/scripts/install.ps1](https://raw.githubusercontent.com/mi8bi/NameTidy/main/scripts/install.ps1)
+    [https://raw.githubusercontent.com/mi8bi/nametidy/main/scripts/install.ps1](https://raw.githubusercontent.com/mi8bi/nametidy/main/scripts/install.ps1)
     (Right-click the link and select "Save link as..." or "Save As...")
 
 2.  **Run the installer:**
@@ -113,13 +113,13 @@ You can use the following scripts to automate the installation of NameTidy. Thes
 
 ## Manual Installation
 
-You can download prebuilt binaries from the [GitHub Releases page](https://github.com/mi8bi/NameTidy/releases):
+You can download prebuilt binaries from the [GitHub Releases page](https://github.com/mi8bi/nametidy/releases):
 
-1. Go to the [Releases](https://github.com/mi8bi/NameTidy/releases) page on GitHub.
-2. Find the latest release and download the binary file for your OS and architecture (e.g., `NameTidy_windows_amd64.zip` or `NameTidy_linux_amd64.tar.gz`).
+1. Go to the [Releases](https://github.com/mi8bi/nametidy/releases) page on GitHub.
+2. Find the latest release and download the binary file for your OS and architecture (e.g., `nametidy_windows_amd64.zip` or `nametidy_linux_amd64.tar.gz`).
 3. Extract the archive. For `.tar.gz` files on Linux/macOS:
    ```bash
-   tar -xzvf NameTidy_VERSION_OS_ARCH.tar.gz
+   tar -xzvf nametidy_VERSION_OS_ARCH.tar.gz
    ```
    For `.zip` files on Windows, you can use File Explorer's built-in "Extract All..." option.
 4. Move the extracted `nametidy` (or `nametidy.exe` on Windows) executable to a directory in your system's PATH.
@@ -132,19 +132,19 @@ You can download prebuilt binaries from the [GitHub Releases page](https://githu
 
 ## Build
 
-NameTidy is written in Go. To install it locally:
+nametidy is written in Go. To install it locally:
 
 1. Make sure Go is installed: https://golang.org/dl/
 2. Clone the repository:
 
 ```bash
-git clone https://github.com/mi8bi/NameTidy.git
+git clone https://github.com/mi8bi/nametidy.git
 ```
 
 3. Build the project with Go:
 
 ```bash
-cd NameTidy
+cd nametidy
 go build
 ```
 
@@ -157,7 +157,7 @@ Organize and standardize file names in your target directory using intuitive sub
 Removes unwanted characters, converts spaces to underscores, and standardizes file names.
 
 ```bash
-NameTidy clean -p ./test_dir
+nametidy clean -p ./test_dir
 ```
 
 #### Example Output:
@@ -165,15 +165,15 @@ NameTidy clean -p ./test_dir
 ```
 Renamed: ./test_dir/file (1).txt → ./test_dir/file_1.txt
 Renamed: ./test_dir/hello world.txt → ./test_dir/hello_world.txt
-History file path: ./test_dir/.NameTidy_History
+History file path: ./test_dir/.nametidy_history
 ```
 
 
 ### Undo Changes
-Restores the most recent file renaming performed by NameTidy
+Restores the most recent file renaming performed by nametidy
 
 ```bash
-NameTidy undo -p ./test_dir
+nametidy undo -p ./test_dir
 ```
 
 #### Example Output:
@@ -188,7 +188,7 @@ Restored: ./test_dir/hello_world.txt → ./test_dir/hello world.txt
 Displays changes without modifying any files.
 
 ```bash
-NameTidy clean -p ./test_dir -d
+nametidy clean -p ./test_dir -d
 ```
 
 #### Example Output:
@@ -203,7 +203,7 @@ NameTidy clean -p ./test_dir -d
 Enables detailed logs of the renaming process.
 
 ```bash
-NameTidy clean -p ./test_dir -v
+nametidy clean -p ./test_dir -v
 ```
 
 #### Example Output:
@@ -212,7 +212,7 @@ NameTidy clean -p ./test_dir -v
 2025/03/30 17:39:08 [INFO] Starting file name cleanup...
 Renamed: ./test_dir/file (1).txt → ./test_dir/file_1.txt
 Renamed: ./test_dir/hello world.txt → ./test_dir/hello_world.txt
-History file path: ./test_dir/.NameTidy_History
+History file path: ./test_dir/.nametidy_history
 2025/03/30 17:39:08 [INFO] File name cleanup completed.
 ```
 
@@ -220,7 +220,7 @@ History file path: ./test_dir/.NameTidy_History
 Adds numerical prefixes to file names. Use -n to set digit length, and -H for hierarchical mode.
 
 ```bash
-NameTidy number -p ./test_dir -n 3
+nametidy number -p ./test_dir -n 3
 ```
 
 #### Example Output:
@@ -232,7 +232,7 @@ Renamed: ./test_dir/photo.jpg → ./test_dir/002_photo.jpg
 
 
 ```bash
-NameTidy number -p ./test_dir -n 3 -H
+nametidy number -p ./test_dir -n 3 -H
 ```
 
 #### Example Output:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,7 @@ var cfgFile string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "NameTidy",
+	Use:   "nametidy",
 	Short: "A brief description of your application",
 	Long: `A longer description that spans multiple lines and likely contains
 examples and usage of using your application. For example:
@@ -62,7 +62,7 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.NameTidy.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.nametidy.yaml)")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
@@ -79,10 +79,10 @@ func initConfig() {
 		home, err := os.UserHomeDir()
 		cobra.CheckErr(err)
 
-		// Search config in home directory with name ".NameTidy" (without extension).
+		// Search config in home directory with name ".nametidy" (without extension).
 		viper.AddConfigPath(home)
 		viper.SetConfigType("yaml")
-		viper.SetConfigName(".NameTidy")
+		viper.SetConfigName(".nametidy")
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -1,15 +1,15 @@
 @echo off
 setlocal enabledelayedexpansion
 
-:: Script to download and install the latest NameTidy binary for Windows
+:: Script to download and install the latest nametidy binary for Windows
 
-echo NameTidy Installer for Windows
+echo nametidy Installer for Windows
 echo ------------------------------
 
 :: --- Configuration ---
 set "BINARY_NAME=nametidy.exe"
 set "INSTALL_DIR=%USERPROFILE%\bin"
-set "RELEASE_BASE_URL=https://github.com/mi8bi/NameTidy/releases/latest/download"
+set "RELEASE_BASE_URL=https://github.com/mi8bi/nametidy/releases/latest/download"
 set "OS_NAME=windows"
 set "ARCH="
 set "MANUAL_MOVE_NEEDED=false"
@@ -30,7 +30,7 @@ echo Detected Architecture: %ARCH%
 :: --- Fetch Latest Release Information ---
 echo.
 echo Fetching latest release information...
-set "LATEST_RELEASE_INFO_URL=https://api.github.com/repos/mi8bi/NameTidy/releases/latest"
+set "LATEST_RELEASE_INFO_URL=https://api.github.com/repos/mi8bi/nametidy/releases/latest"
 set "TEMP_JSON_FILE=%TEMP%\release_info_%RANDOM%.json"
 set "TAG_NAME="
 set "VERSION="
@@ -91,15 +91,15 @@ if not defined VERSION (
 echo Detected version: %VERSION%
 
 :: Construct the download URL
-set "RELEASE_DOWNLOAD_URL_BASE=https://github.com/mi8bi/NameTidy/releases/download"
-set "ASSET_NAME=NameTidy_%VERSION%_%OS_NAME%_%ARCH%.zip"
+set "RELEASE_DOWNLOAD_URL_BASE=https://github.com/mi8bi/nametidy/releases/download"
+set "ASSET_NAME=nametidy_%VERSION%_%OS_NAME%_%ARCH%.zip"
 set "DOWNLOAD_URL=%RELEASE_DOWNLOAD_URL_BASE%/%TAG_NAME%/%ASSET_NAME%"
 
 echo Download URL: %DOWNLOAD_URL%
 
 :: --- Temporary Download Path ---
 :: Create a temporary directory for downloads
-set "TEMP_DIR=%TEMP%\NameTidy_Install_%RANDOM%"
+set "TEMP_DIR=%TEMP%\nametidy_Install_%RANDOM%"
 mkdir "%TEMP_DIR%"
 if not exist "%TEMP_DIR%\" (
     echo Error: Failed to create temporary directory: %TEMP_DIR%
@@ -111,7 +111,7 @@ set "EXTRACTED_BINARY_PATH=%TEMP_DIR%\%BINARY_NAME%"
 
 :: --- Download Logic ---
 echo.
-echo Downloading NameTidy release asset...
+echo Downloading nametidy release asset...
 
 :: Check for curl
 where curl >nul 2>nul
@@ -131,7 +131,7 @@ if %errorlevel% equ 0 (
 where bitsadmin >nul 2>nul
 if %errorlevel% equ 0 (
     echo Found bitsadmin. Attempting download...
-    bitsadmin /transfer NameTidyDownloadJob /download /priority NORMAL "%DOWNLOAD_URL%" "%ARCHIVE_PATH%"
+    bitsadmin /transfer nametidyDownloadJob /download /priority NORMAL "%DOWNLOAD_URL%" "%ARCHIVE_PATH%"
     if errorlevel 1 (
         echo Error: bitsadmin download failed. Check URL or network connection.
         echo Asset might not be available for %OS_NAME%/%ARCH%.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,9 +1,9 @@
 #Requires -Version 5.0
 <#
 .SYNOPSIS
-    Installs the NameTidy utility for Windows.
+    Installs the nametidy utility for Windows.
 .DESCRIPTION
-    This script downloads the latest version of NameTidy for the appropriate
+    This script downloads the latest version of nametidy for the appropriate
     architecture, extracts it, installs it to $env:USERPROFILE\bin, and
     attempts to add this directory to the user's PATH environment variable.
 .NOTES
@@ -20,13 +20,13 @@ $InstallBaseDir = $env:USERPROFILE
 $InstallRelativePath = "bin" # Relative to InstallBaseDir
 $InstallDir = Join-Path -Path $InstallBaseDir -ChildPath $InstallRelativePath
 
-$ReleaseBaseUrl = "https://github.com/mi8bi/NameTidy/releases/latest/download"
+$ReleaseBaseUrl = "https://github.com/mi8bi/nametidy/releases/latest/download"
 $OsName = "windows"
 $Architecture = ""
 
 # --- Temporary Path ---
 # Create a temporary directory for downloads and extraction
-$TempDir = Join-Path -Path $env:TEMP -ChildPath "NameTidy_Install_$($PID)_$(Get-Random)"
+$TempDir = Join-Path -Path $env:TEMP -ChildPath "nametidy_Install_$($PID)_$(Get-Random)"
 try {
     if (Test-Path $TempDir) {
         Write-Warning "Temporary directory $TempDir already exists. Removing."
@@ -42,12 +42,12 @@ catch {
 
 # --- Main Script Logic ---
 try {
-    Write-Host "NameTidy Installer for Windows PowerShell"
+    Write-Host "nametidy Installer for Windows PowerShell"
     Write-Host "---------------------------------------"
 
     # --- Fetch Latest Release Information ---
     Write-Host "Fetching latest release information..."
-    $LatestReleaseInfoUrl = "https://api.github.com/repos/mi8bi/NameTidy/releases/latest"
+    $LatestReleaseInfoUrl = "https://api.github.com/repos/mi8bi/nametidy/releases/latest"
     $TagName = ""
     $Version = ""
 
@@ -95,17 +95,17 @@ try {
     # $OsName is already defined in Configuration section
     # $Architecture is determined above
     # $Version and $TagName are from the new block above
-    $AssetName = "NameTidy_${Version}_${OsName}_${Architecture}.zip"
+    $AssetName = "nametidy_${Version}_${OsName}_${Architecture}.zip"
     # Construct specific download URL using the tag
-    $DownloadUrl = "https://github.com/mi8bi/NameTidy/releases/download/${TagName}/${AssetName}"
-    # Example: https://github.com/mi8bi/NameTidy/releases/download/v0.1.0/NameTidy_0.1.0_windows_amd64.zip
+    $DownloadUrl = "https://github.com/mi8bi/nametidy/releases/download/${TagName}/${AssetName}"
+    # Example: https://github.com/mi8bi/nametidy/releases/download/v0.1.0/nametidy_0.1.0_windows_amd64.zip
     $ArchiveFilePath = Join-Path -Path $TempDir -ChildPath $AssetName
     $ExtractedBinaryPath = Join-Path -Path $TempDir -ChildPath $BinaryName # Assuming it's at the root of the zip
 
     Write-Host "Download URL: $DownloadUrl"
 
     # --- Download ---
-    Write-Host "Downloading NameTidy release asset..."
+    Write-Host "Downloading nametidy release asset..."
     try {
         Invoke-WebRequest -Uri $DownloadUrl -OutFile $ArchiveFilePath -UseBasicParsing
         Write-Host "Download successful: $ArchiveFilePath"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Script to download and install the latest NameTidy binary
+# Script to download and install the latest nametidy binary
 
 # Exit immediately if a command exits with a non-zero status.
 set -e
@@ -70,7 +70,7 @@ download_file() {
 }
 
 # --- Main Script ---
-echo "NameTidy Installer"
+echo "nametidy Installer"
 echo "------------------"
 
 # Create a temporary directory for download
@@ -108,7 +108,7 @@ echo "Detected Architecture: $ARCH"
 
 # Fetch the latest release tag and version
 echo "Fetching latest release information..."
-LATEST_RELEASE_INFO_URL="https://api.github.com/repos/mi8bi/NameTidy/releases/latest"
+LATEST_RELEASE_INFO_URL="https://api.github.com/repos/mi8bi/nametidy/releases/latest"
 
 # Attempt to fetch tag_name using curl and grep/sed
 # This extracts the value of "tag_name": "vX.Y.Z"
@@ -144,10 +144,10 @@ echo "Detected version: $VERSION"
 # Construct the download URL using the fetched tag and version
 # Note: For Windows, the script might use .zip. This script is .sh, so .tar.gz is appropriate.
 # The ASSET_NAME now includes the VERSION.
-RELEASE_DOWNLOAD_URL_BASE="https://github.com/mi8bi/NameTidy/releases/download"
-ASSET_NAME="NameTidy_${VERSION}_${OS}_${ARCH}.tar.gz"
+RELEASE_DOWNLOAD_URL_BASE="https://github.com/mi8bi/nametidy/releases/download"
+ASSET_NAME="nametidy_${VERSION}_${OS}_${ARCH}.tar.gz"
 DOWNLOAD_URL="${RELEASE_DOWNLOAD_URL_BASE}/${TAG_NAME}/${ASSET_NAME}"
-# Example: https://github.com/mi8bi/NameTidy/releases/download/v0.1.0/NameTidy_0.1.0_linux_amd64.tar.gz
+# Example: https://github.com/mi8bi/nametidy/releases/download/v0.1.0/nametidy_0.1.0_linux_amd64.tar.gz
 
 echo "Constructed download URL: $DOWNLOAD_URL"
 
@@ -155,7 +155,7 @@ echo "Constructed download URL: $DOWNLOAD_URL"
 ARCHIVE_PATH="${TMP_DIR}/${ASSET_NAME}"
 
 # Download the archive
-echo "Downloading NameTidy release asset..."
+echo "Downloading nametidy release asset..."
 if ! download_file "$DOWNLOAD_URL" "$ARCHIVE_PATH"; then
     echo "Error: Download failed from $DOWNLOAD_URL."
     echo "Please check the URL and your internet connection."


### PR DESCRIPTION
This commit standardizes the project's naming to 'nametidy' across various files and user-facing text for consistency and to align with common CLI tool naming conventions.

Changes include:
- Updated README.md to use 'nametidy' in text, links, and command examples. The reference to the history file in examples was changed to '.nametidy_history'.
- Modified cmd/root.go to set the command name to 'nametidy' and the default config file to '.nametidy.yaml'.
- Updated installation scripts (install.sh, install.cmd, install.ps1) to use 'nametidy' in messages, comments, and download URLs/asset names.
- Verified that user-facing instances of 'NameTidy' in other Go source files were already addressed or not present. Occurrences in import paths (Go module name) were not changed.
- Confirmed with you that the existing history database filename ('.name_tidy_history.db') is acceptable.

This addresses issue #23 by unifying the naming convention. The GitHub repository description should be manually updated to 'nametidy' if it still reflects 'NameTidy'.