### PR TITLE
Fix: Address issues from PR #26 review and tests

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -17,7 +17,7 @@ var cleanCmd = &cobra.Command{
 
 		db, err := handleCommonInitializations(verbose, dirPath, true)
 		if err != nil {
-			utils.Error(err.Error(), nil) // Assuming utils.Error can take a string and nil error
+			utils.Error("Error during common initialization: %v", err)
 			return
 		}
 

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -22,7 +22,7 @@ var historyClearCmd = &cobra.Command{
 		// For history clear, dirPath is not needed, so pass "" and checkDir=false
 		db, err := handleCommonInitializations(verbose, "", false)
 		if err != nil {
-			utils.Error(err.Error(), nil)
+			utils.Error("Error during common initialization: %v", err)
 			return
 		}
 

--- a/cmd/number.go
+++ b/cmd/number.go
@@ -19,7 +19,7 @@ var numberCmd = &cobra.Command{
 
 		db, err := handleCommonInitializations(verbose, dirPath, true)
 		if err != nil {
-			utils.Error(err.Error(), nil)
+			utils.Error("Error during common initialization: %v", err)
 			return
 		}
 

--- a/cmd/redo.go
+++ b/cmd/redo.go
@@ -20,7 +20,7 @@ var redoCmd = &cobra.Command{
 
 		db, err := handleCommonInitializations(verbose, dirPath, true)
 		if err != nil {
-			utils.Error(err.Error(), nil)
+			utils.Error("Error during common initialization: %v", err)
 			return
 		}
 

--- a/cmd/undo.go
+++ b/cmd/undo.go
@@ -17,7 +17,7 @@ var undoCmd = &cobra.Command{
 
 		db, err := handleCommonInitializations(verbose, dirPath, true)
 		if err != nil {
-			utils.Error(err.Error(), nil)
+			utils.Error("Error during common initialization: %v", err)
 			return
 		}
 

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -63,11 +63,7 @@ func TestHandleCommonInitializations(t *testing.T) {
 	// Test Case 1: Successful initialization
 	t.Run("SuccessfulInitialization", func(t *testing.T) {
 		// For this test, we need a directory that exists.
-		tempDir, err := os.MkdirTemp("", "testdir")
-		if err != nil {
-			t.Fatalf("Failed to create temp dir: %v", err)
-		}
-		defer os.RemoveAll(tempDir)
+		tempDir := t.TempDir()
 
 		// The real GetDB will be called. For success, it should work.
 		// If it fails due to environment, this test will fail.
@@ -85,9 +81,12 @@ func TestHandleCommonInitializations(t *testing.T) {
 
 	// Test Case 2: Directory does not exist
 	t.Run("DirectoryDoesNotExist", func(t *testing.T) {
-		nonExistentDir := filepath.Join(os.TempDir(), "non_existent_dir_for_test")
-		// Ensure it really doesn't exist from a previous failed run
-		_ = os.RemoveAll(nonExistentDir)
+		baseDir := t.TempDir()
+		nonExistentDir := filepath.Join(baseDir, "non_existent_dir_for_test")
+		// t.TempDir() creates a unique directory, so nonExistentDir inside it won't exist
+		// unless explicitly created. If we want to be absolutely sure, we can attempt a remove.
+		// However, for a "non-existent" test, simply joining a new name within a fresh tempDir is usually sufficient.
+		// _ = os.RemoveAll(nonExistentDir) // This line is likely not needed anymore.
 
 		// The real GetDB will be called by handleCommonInitializations after the dir check.
 		// This is okay as the function should error out before that if dir doesn't exist.
@@ -115,11 +114,7 @@ func TestHandleCommonInitializations(t *testing.T) {
 		// This test is more of a placeholder for the desired behavior if mocking were possible.
 		// If cleaner.GetDB actually fails in the test env, this test might pass by catching that.
 		// We will create a directory so the IsDirectory check passes.
-		tempDir, err := os.MkdirTemp("", "testdir_db_fail")
-		if err != nil {
-			t.Fatalf("Failed to create temp dir: %v", err)
-		}
-		defer os.RemoveAll(tempDir)
+		tempDir := t.TempDir()
 
 		// --- This is where true mocking of cleaner.GetDB would be needed ---
 		// Hypothetical: originalGetDBFunc := cleaner.GetDB
@@ -155,8 +150,10 @@ func TestHandleCommonInitializations(t *testing.T) {
 	t.Run("CheckDirIsFalse", func(t *testing.T) {
 		// For this test, IsDirectory should not be called.
 		// We use a non-existent path; if IsDirectory were called, it would fail.
-		nonExistentDir := filepath.Join(os.TempDir(), "non_existent_for_checkdir_false")
-		_ = os.RemoveAll(nonExistentDir) // ensure it's not there
+		baseDir := t.TempDir()
+		nonExistentDir := filepath.Join(baseDir, "non_existent_for_checkdir_false")
+		// As above, joining a new name within a fresh tempDir is usually sufficient for it to be non-existent.
+		// _ = os.RemoveAll(nonExistentDir) // This line is likely not needed anymore.
 
 		// The real GetDB will be called.
 		db, err := handleCommonInitializations(false, nonExistentDir, false)

--- a/internal/cleaner/process_test.go
+++ b/internal/cleaner/process_test.go
@@ -3,6 +3,7 @@ package cleaner
 import (
 	"NameTidy/internal/utils" // For utils.Info/Error if we want to check logs
 	"errors"
+	_ "gorm.io/driver/sqlite"
 	"fmt"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
This commit addresses several issues identified in the review of PR #26 and during test execution.

Key changes:

- Improved error logging in command files (`cmd/*.go`) to include context-specific messages and the original error object, per Gemini Code Assist feedback.
- Added missing SQLite driver import (`gorm.io/driver/sqlite`) in `internal/cleaner/process_test.go`.
- Corrected test helper function calls in `internal/cleaner/process_test.go`.
- Modified `cmd/utils_test.go` to use secure temporary file creation methods (`t.TempDir()`), addressing a SonarQube finding.
- Refactored `internal/cleaner/process_test.go` to reduce local code duplication by introducing a `setupTestDB` helper function.
- Fixed various build errors in test files, including unused imports and undefined variables.

Known Limitations:

- SonarQube: Code duplication in `internal/cleaner/cleaner.go` could not be fully addressed. I was unable to modify this file to use the generic `ProcessFiles` function due to persistent errors.
- Test Failures: Tests for the `NameTidy/internal/cleaner` package fail due to a redeclared helper function (`setupTestDB`) in `internal/cleaner/history_test.go`. I was also unable to modify this file to remove the duplicate declaration.

Despite these limitations, the changes improve the codebase by addressing several review comments and fixing multiple test issues.